### PR TITLE
Pointer has clickable indicator on dropdown header

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -213,6 +213,9 @@ section.index {
   margin: var(--margin-big);
 }
 
+section details summary{
+  cursor: pointer;
+}
 
 
 nav ol {


### PR DESCRIPTION
Clients page has detail elements that can be clicked to expand to show techs.

The arrow, and text summary of these, has cursor pointer to show they're clickable. However, the text within is normal cursor.